### PR TITLE
use nodeify instead of letting errors escape

### DIFF
--- a/authenticator.js
+++ b/authenticator.js
@@ -29,26 +29,25 @@ AuthenticateGithub.prototype.authenticate = function(credentials, cb) {
 
   this.getAuthorizationToken(username, password, twoFactorCode)
     .then(function(token) {
-      cb(undefined, {
+      return {
         token: token,
         user: {
           name: username,
           email: body.email || 'npme@example.com'
         }
-      });
-    })
-    .catch(function(err) {
+      };
+    }, function(err) {
       if (err.code === 401) {
         err.message = 'unauthorized';
         // this is a failure to auth, but not an error
-        cb(null,err);
+        return err;
       } else if (err.code === 500) {
         err.message = 'GitHub enterprise unavailable';
-        // this is an error state
-        cb(err)
       }
+      // this is an error state
+      throw err;
     })
-    .done();
+    .nodeify(cb);
 };
 
 AuthenticateGithub.prototype._validateCredentials = function(credentials) {

--- a/test/authenticate-test.js
+++ b/test/authenticate-test.js
@@ -196,4 +196,27 @@ Lab.experiment('authenticate', function() {
     });
   });
 
+  Lab.it('executes callback with error if GHE API fails with unexpected status code', function(done) {
+    var authenticateGithub = new AuthenticateGithub({
+      githubHost: 'https://github.example.com',
+      timestamp: function() {
+        return 0;
+      }
+    });
+
+    var packageApi = nock('https://github.example.com')
+      .post('/api/v3/authorizations')
+      .reply(432);
+
+    authenticateGithub.authenticate({
+      body: {
+        name: 'bcoe-test',
+        password: 'foobar'
+      }
+    }, function(err, resp) {
+      Code.expect(err.code).to.deep.equal(432);
+      packageApi.done();
+      done();
+    });
+  });
 });

--- a/test/authenticate-test.js
+++ b/test/authenticate-test.js
@@ -97,6 +97,7 @@ Lab.experiment('getAuthorizationToken', function() {
 
     authenticateGithub.getAuthorizationToken('bcoe-test', 'foobar').catch(function(err) {
       Code.expect(err.code).to.deep.equal(500);
+      packageApi.done();
       done();
     }).done();
   });


### PR DESCRIPTION
Currently, it crashes the process if the error doesn't have one of the two expected codes.
Maybe I'm mistaken, and this is intentional.