### PR TITLE
allows an alternative redis URL to be provided

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "github": "0.2.2",
     "github-url-from-git": "^1.4.0",
     "lodash": "^2.4.1",
-    "redis": "^0.12.1",
+    "redis": "^1.0.0",
     "request": "^2.47.0"
   },
   "license": "ISC",

--- a/session.js
+++ b/session.js
@@ -8,7 +8,7 @@ var _ = require('lodash'),
 // the token is not found in the DB.
 function SessionGithub(opts) {
   _.extend(this, {
-    client: redis.createClient(),
+    client: redis.createClient(process.env.LOGIN_CACHE_REDIS),
     githubHost: 'api.github.com',
     debug: true,
     githubPathPrefix: '/api/v3'


### PR DESCRIPTION
This allows an alternative redis URL to be provided (I'm starting to split npmO into multiple containers).