### PR TITLE
Added support for github redirects

### DIFF
--- a/authenticator.js
+++ b/authenticator.js
@@ -86,7 +86,7 @@ AuthenticateGithub.prototype.getAuthorizationToken = function(username, password
     });
   }).then(this.githubOrg && function(token) {
     return new Promise(function(resolve, reject) {
-      github.orgs.getMember({ user: username, org: _this.githubOrg }, function(err, res) {
+      github.orgs.checkMembership({ org: _this.githubOrg, user: username}, function (err, res) {
         if (err) reject(err);
         else resolve(token);
       });

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   "dependencies": {
     "@npm/enterprise-configurator": "~0.1.8",
     "bluebird": "^3.4.0",
-    "github": "^0.2.4",
+    "github": "^3.1.1",
     "github-url-from-git": "^1.4.0",
     "lodash": "^4.12.0",
     "redis": "^2.5.3",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,6 @@
     "release": "standard-version"
   },
   "dependencies": {
-    "@npm/enterprise-configurator": "~0.1.8",
     "bluebird": "^3.4.0",
     "github": "^3.1.1",
     "github-url-from-git": "^1.4.0",
@@ -21,6 +20,7 @@
   },
   "license": "ISC",
   "devDependencies": {
+    "@npm/enterprise-configurator": "git://github.com/npm/enterprise-configurator#v0.1.26",
     "code": "^2.3.0",
     "lab": "^10.6.0",
     "nock": "^8.0.0",

--- a/session.js
+++ b/session.js
@@ -45,7 +45,7 @@ SessionGithub.prototype._githubLookup = function(key, cb) {
     token: token
   });
 
-  github.user.get({}, function(err, res) {
+  github.users.get({}, function(err, res) {
     if (err) cb(err);
     else if (res.code < 200 || res.code >= 400) cb(Error('status = ' + res.code));
     else {


### PR DESCRIPTION
When github projects are moved and a redirect left behind authorization breaks because github library 0.2.4 doesn't support redirects and just returns the redirect object which has no permissions attribute (needed by subsequently called _handleGithubResponse.

The latest github library 3.1.1 does support redirects so the response for github.repos.get will include the permissions attribute.
