### PR TITLE
Fix organization check when multi-org is configured

### DIFF
--- a/authenticator.js
+++ b/authenticator.js
@@ -85,7 +85,7 @@ AuthenticateGithub.prototype.getAuthorizationToken = function(username, password
       else resolve(res.token);
     });
   }).then(this.githubOrg && function(token) {
-    var orgs = !Array.isArray(_this.githubOrg) ? _this.githubOrg.split(/,[\s]*/) : value;
+    var orgs = Array.isArray(_this.githubOrg) ? _this.githubOrg : _this.githubOrg.split(/,[\s]*/);
     return Promise.any([].concat(orgs).map(function (githubOrg) {
       return new Promise(function(resolve, reject) {
          github.orgs.checkMembership({ user: username, org: githubOrg }, function(err, res) {

--- a/authorizer.js
+++ b/authorizer.js
@@ -80,7 +80,12 @@ AuthorizeGithub.prototype.isAuthorized = function() {
     _this.loadPackageJSON().then(function(packageJson) {
       return _this.parseGitUrl(packageJson);
     }).then(function(githubParams) {
-      if (_this.githubOrg && githubParams.org !== _this.githubOrg) return reject(Error('invalid organization name'));
+      if (_this.githubOrg) {
+        var orgs = Array.isArray(_this.githubOrg) ? _this.githubOrg : _this.githubOrg.split(/,[\s]*/);
+        if (orgs.indexOf(githubParams.org) === -1) {
+          return reject(Error('invalid organization name'));
+        }
+      }
 
       var github = createGithubApi(_this);
 

--- a/test/authorize-test.js
+++ b/test/authorize-test.js
@@ -120,7 +120,7 @@ Lab.experiment('loadPackageJSON', function() {
     });
   });
 
-  Lab.test.only('gracefully handles request returning an error', function(done) {
+  Lab.test('gracefully handles request returning an error', function(done) {
     nock.cleanAll();
 
     var ga = new AuthorizeGithub({
@@ -388,6 +388,40 @@ Lab.experiment('isAuthorized', function() {
       token: 'banana',
       scope: 'publish',
       githubOrg: 'npm-test',
+      debug: false
+    });
+
+    ga.isAuthorized().done(function(authorized) {
+      assert(authorized);
+
+      packageApi.done();
+      githubApi.done();
+      done();
+    });
+  });
+
+  Lab.test('authorization succeeds on publish, if git-URL-org matches any githubOrg', function(done) {
+
+    // HTTP response for loading package.json
+    var packageApi = nock('http://frontdoor.npmjs.com')
+      .get('/@npm-test/foo?sharedFetchSecret=' + config.sharedFetchSecret)
+      .reply(200, JSON.stringify({
+        repository: { url: 'http://github.npmjs.com/npm-test/foo.git' }
+      }));
+
+    // HTTP response for use with read/write permissions on repo.
+    var githubApi = nock('https://github.example.com')
+      .get('/api/v3/repos/npm-test/foo?access_token=banana')
+      .reply(200, fs.readFileSync('./test/fixtures/read-write.json'), {
+        'content-type': 'application/json; charset=utf-8'
+      })
+
+    var ga = new AuthorizeGithub({
+      frontDoorHost: 'http://frontdoor.npmjs.com',
+      packagePath: '/@npm-test/foo',
+      token: 'banana',
+      scope: 'publish',
+      githubOrg: 'otherOrg, npm-test, org3',
       debug: false
     });
 


### PR DESCRIPTION
This PR fixes the organization check in the **authorizer.js** when npm is configured to support multiple organizations.